### PR TITLE
Strips null props

### DIFF
--- a/opengraph/core.py
+++ b/opengraph/core.py
@@ -57,9 +57,9 @@ class Node:
     def __post_init__(self):
         """Validate node data after initialization."""
         self._validate_kinds()
-        
-        # Validate properties if present
+        # Strip properties with null values
         if self.properties:
+            self.properties = {k: v for k, v in self.properties.items() if v is not None}
             self._validate_properties()
     
     def _validate_kinds(self):
@@ -97,7 +97,10 @@ class Node:
             "kinds": self.kinds
         }
         if self.properties is not None:
-            result["properties"] = self.properties
+            # Strip properties with null values on serialization
+            props = {k: v for k, v in self.properties.items() if v is not None}
+            if props:
+                result["properties"] = props
         return result
 
 
@@ -121,9 +124,9 @@ class Edge:
         """Validate edge data after initialization."""
         if not self.kind:
             raise ValueError("Edge must have a kind")
-        
-        # Validate properties if present
+        # Strip properties with null values
         if self.properties:
+            self.properties = {k: v for k, v in self.properties.items() if v is not None}
             self._validate_properties()
     
     def _validate_properties(self):
@@ -153,7 +156,10 @@ class Edge:
             "kind": self.kind
         }
         if self.properties is not None:
-            result["properties"] = self.properties
+            # Strip properties with null values on serialization
+            props = {k: v for k, v in self.properties.items() if v is not None}
+            if props:
+                result["properties"] = props
         return result
 
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -50,7 +50,6 @@ class TestNode:
             "int_prop": 42,
             "float_prop": 3.14,
             "bool_prop": True,
-            "none_prop": None,
             "string_array": ["item1", "item2", "item3"],
             "int_array": [1, 2, 3],
             "bool_array": [True, False, True],
@@ -70,6 +69,19 @@ class TestNode:
         # Test rejection of object arrays
         with pytest.raises(ValueError, match="array cannot contain objects"):
             Node(id="test123", kinds=["User"], properties={"objects": [{"key": "value"}]})
+
+    def test_node_property_validation_none_prop(self):
+        """Test that properties with None values are stripped."""
+        properties_with_none = {
+            "valid_prop": "test",
+            "none_prop": None,
+            "another_valid": 42
+        }
+        node = Node(id="test123", kinds=["User"], properties=properties_with_none)
+        assert node.properties == {
+            "valid_prop": "test",
+            "another_valid": 42
+        }
 
     def test_node_to_dict_comprehensive(self):
         """Test converting nodes to dictionary in various scenarios."""


### PR DESCRIPTION
This pull request improves how properties with null (`None`) values are handled in the `Node` and `Edge` classes in `opengraph/core.py`. Now, any properties with `None` values are automatically stripped out during both initialization and serialization, ensuring cleaner data structures. Additional tests are included to verify this behavior.